### PR TITLE
Support popup a widget to show error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -151,9 +151,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -173,11 +173,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "equivalent"
@@ -317,12 +317,6 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -372,9 +366,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -431,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mio"
@@ -507,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -542,9 +536,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -600,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -612,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -623,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc_version"
@@ -651,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -809,11 +803,11 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -822,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -859,18 +853,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -912,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "indexmap",
  "serde",
@@ -934,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "serde",
@@ -948,7 +942,7 @@ dependencies = [
 [[package]]
 name = "tui-tree-widget"
 version = "0.20.0"
-source = "git+https://github.com/EdJoPaTo/tui-rs-tree-widget.git?rev=fec6321d3ca2273f6715ab2fb98560aea1b557b6#fec6321d3ca2273f6715ab2fb98560aea1b557b6"
+source = "git+https://github.com/EdJoPaTo/tui-rs-tree-widget.git?rev=dceb9f87b0afc12695b633d17f7f86690a2ec682#dceb9f87b0afc12695b633d17f7f86690a2ec682"
 dependencies = [
  "ratatui",
  "unicode-width",
@@ -978,15 +972,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vergen"
@@ -1197,9 +1191,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.117", features = ["preserve_order"] }
 serde_yml = "0.0.10"
 toml = { version = "0.8.13", features = ["preserve_order"] }
-tui-tree-widget = { git = "https://github.com/EdJoPaTo/tui-rs-tree-widget.git", rev = "fec6321d3ca2273f6715ab2fb98560aea1b557b6" }
+tui-tree-widget = { git = "https://github.com/EdJoPaTo/tui-rs-tree-widget.git", rev = "dceb9f87b0afc12695b633d17f7f86690a2ec682" }
 
 [build-dependencies]
 simple-error = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For how to configure TUI colors, please refer to: [Colors Document](docs/colors.
 - [x] UI: Data Block (v0.1)
 - [ ] UI: Footer to show current attached root path
 - [ ] UI: Filter Input
-- [ ] UI: Popup widget to show error or help messages
+- [x] UI: Popup widget to show error or help messages (v0.2)
 - [x] Action: Change current selected item as root (v0.1)
 - [x] Action: Back to previous root (v0.1)
 - [x] Action: Scale up/down tree widget (v0.1)

--- a/src/config/colors.rs
+++ b/src/config/colors.rs
@@ -30,9 +30,12 @@ pub struct Colors {
 
     #[serde(default = "DataColors::default")]
     pub data: DataColors,
+
+    #[serde(default = "PopupColors::default")]
+    pub popup: PopupColors,
 }
 
-generate_colors_parse!(Colors, header, tree, data, focus_border);
+generate_colors_parse!(Colors, header, tree, data, focus_border, popup);
 
 impl Colors {
     pub fn default() -> Self {
@@ -41,6 +44,7 @@ impl Colors {
             tree: TreeColors::default(),
             data: DataColors::default(),
             focus_border: Self::default_focus_boder(),
+            popup: PopupColors::default(),
         }
     }
 
@@ -206,6 +210,26 @@ impl TreeColors {
 
     fn default_description() -> Color {
         Color::new("dark_gray", "", false, false)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PopupColors {
+    #[serde(default = "PopupColors::default_error_text")]
+    pub error_text: Color,
+}
+
+generate_colors_parse!(PopupColors, error_text);
+
+impl PopupColors {
+    fn default() -> Self {
+        Self {
+            error_text: Self::default_error_text(),
+        }
+    }
+
+    fn default_error_text() -> Color {
+        Color::new("red", "", false, false)
     }
 }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -11,9 +11,8 @@ use crate::config::{Config, LayoutDirection};
 use crate::tree::Tree;
 use crate::ui::data_block::DataBlock;
 use crate::ui::header::{Header, HeaderContext};
+use crate::ui::popup::{Popup, PopupLevel};
 use crate::ui::tree_overview::TreeOverview;
-
-use super::popup::{Popup, PopupLevel};
 
 enum Refresh {
     /// Update the TUI

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 mod app;
 mod data_block;
 mod header;
+mod popup;
 mod tree_overview;
 
 use std::io::Stdout;

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -1,0 +1,140 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Layout, Rect},
+    text::Text,
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::config::{keys::Action, Config};
+
+use super::app::ScrollDirection;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum PopupLevel {
+    Error,
+}
+
+pub(super) struct Popup<'a> {
+    data: Option<(String, PopupLevel)>,
+
+    cfg: &'a Config,
+
+    scroll: usize,
+}
+
+impl<'a> Popup<'a> {
+    pub(super) fn new(cfg: &'a Config) -> Self {
+        Self {
+            data: None,
+            cfg,
+            scroll: 0,
+        }
+    }
+
+    pub(super) fn set_data(&mut self, data: String, level: PopupLevel) {
+        self.data = Some((data, level));
+    }
+
+    pub(super) fn on_key(&mut self, action: Action) -> bool {
+        match action {
+            Action::MoveDown => self.scroll_down(1),
+            Action::MoveUp => self.scroll_up(1),
+            Action::SelectFocus | Action::Reset => self.disable(),
+            _ => false,
+        }
+    }
+
+    pub(super) fn on_scroll(&mut self, direction: ScrollDirection) -> bool {
+        match direction {
+            ScrollDirection::Up => self.scroll_up(3),
+            ScrollDirection::Down => self.scroll_down(3),
+        }
+    }
+
+    fn scroll_down(&mut self, lines: usize) -> bool {
+        if self.data.is_none() {
+            return false;
+        }
+
+        self.scroll = self.scroll.saturating_add(lines);
+        true
+    }
+
+    fn scroll_up(&mut self, lines: usize) -> bool {
+        if self.data.is_none() {
+            return false;
+        }
+
+        if self.scroll == 0 {
+            return false;
+        }
+
+        self.scroll = self.scroll.saturating_sub(lines);
+        true
+    }
+
+    pub(super) fn disable(&mut self) -> bool {
+        if self.data.is_none() {
+            return false;
+        }
+
+        self.data = None;
+        self.scroll = 0;
+        true
+    }
+
+    pub(super) fn is_disabled(&self) -> bool {
+        self.data.is_none()
+    }
+
+    pub(super) fn draw(&self, frame: &mut Frame) {
+        let (text, level) = match self.data.as_ref() {
+            Some(data) => data,
+            None => return,
+        };
+
+        let border_color = &self.cfg.colors.focus_border;
+        let (border_style, border_type) = super::get_border_style(border_color, border_color, true);
+
+        let (title, text_style) = match level {
+            PopupLevel::Error => ("error", self.cfg.colors.popup.error_text.style),
+        };
+
+        let block = Block::new()
+            .border_type(border_type)
+            .borders(Borders::ALL)
+            .border_style(border_style)
+            .title_alignment(Alignment::Center)
+            .title(title);
+
+        let text = Text::from(text.as_str());
+
+        let widget = Paragraph::new(text)
+            .style(text_style)
+            .block(block)
+            .wrap(Wrap { trim: false })
+            .scroll((self.scroll as u16, 0));
+
+        let area = Self::centered_rect(50, 50, frame.size());
+        frame.render_widget(Clear, area); // this clears out the background
+        frame.render_widget(widget, area);
+    }
+
+    /// helper function to create a centered rect using up certain percentage of the
+    /// available rect `r`
+    fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+        let popup_layout = Layout::vertical([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+        Layout::horizontal([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+    }
+}

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -1,13 +1,11 @@
-use ratatui::{
-    layout::{Alignment, Constraint, Layout, Rect},
-    text::Text,
-    widgets::{Block, Borders, Clear, Paragraph, Wrap},
-    Frame,
-};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::text::Text;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use ratatui::Frame;
 
-use crate::config::{keys::Action, Config};
-
-use super::app::ScrollDirection;
+use crate::config::keys::Action;
+use crate::config::Config;
+use crate::ui::app::ScrollDirection;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum PopupLevel {


### PR DESCRIPTION
In `App`, now we can use:

```rust
self.popup(String::from("foo"), PopupLevel::Error)
```

to popup a widget to show error message.

This is to prepare for developing more features in the future, since we need a way to display error messages to the user.