### PR TITLE
feat(actions): add edit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For how to configure TUI colors, please refer to: [Colors Document](docs/colors.
 - [x] Action: Mouse click actions
 - [x] Action: Mouse scroll actions
 - [ ] Action: Mouse select actions
-- [x] Action: Open current selected item in editor
+- [x] Action: Open current selected item in editor **ReadOnly** (v0.2)
 - [x] Action: Switch between tree overview and data block (v0.1)
 - [x] Action: Jump to parent item (v0.1)
 - [x] Action: Jump to parent item and close (v0.1)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For how to configure TUI colors, please refer to: [Colors Document](docs/colors.
 - [x] Action: Mouse click actions
 - [x] Action: Mouse scroll actions
 - [ ] Action: Mouse select actions
-- [ ] Action: Open current selected item in editor
+- [x] Action: Open current selected item in editor
 - [x] Action: Switch between tree overview and data block (v0.1)
 - [x] Action: Jump to parent item (v0.1)
 - [x] Action: Jump to parent item and close (v0.1)

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,3 +1,8 @@
+[editor]
+program = "nvim"
+args = ["{{file}}"]
+dir = "/tmp"
+
 [layout]
 direction = "horizontal"
 tree_size = 40

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,5 +1,5 @@
 [editor]
-program = "nvim"
+program = "vim"
 args = ["{{file}}"]
 dir = "/tmp"
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -19,7 +19,7 @@
 | tree_scale_up   | `[`                       | Scale up tree widget                                         |
 | tree_scale_down | `]`                       | Scale down tree widget                                       |
 | switch          | `<tab>`                   | Switch focus widget                                          |
-| edit            | `e`                       | Open current item in editor<br />**Notice that edited changes won't be saved** |
+| edit            | `e`                       | Open current item in editor<br />**(ReadOnly)**              |
 | quit            | `<ctrl-c>`, `q`           | Quit program                                                 |
 
 All available keys:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,25 +1,26 @@
 # All Available Actions
 
-| Action          | Default Keys              | Description                                                   |
-| --------------- | ------------------------- | ------------------------------------------------------------- |
-| move_up         | `k`, `<up>`               | Move cursor up                                                |
-| move_down       | `j`, `<down>`             | Move cursor down                                              |
-| move_left       | `h`, `<left>`             | Move cursor left                                              |
-| move_right      | `l`, `<right>`            | Move cursor right                                             |
-| select_focus    | `<enter>`                 | Toggle select current item                                    |
-| select_parent   | `p`                       | Move cursor to the parent item                                |
-| select_first    | `g`                       | Move cursor to the top                                        |
-| select_last     | `G`                       | Move cursor to the bottom                                     |
-| close_parent    | `<backspace>`             | Move cursor to the parent and close                           |
+| Action          | Default Keys              | Description                                                  |
+| --------------- | ------------------------- | ------------------------------------------------------------ |
+| move_up         | `k`, `<up>`               | Move cursor up                                               |
+| move_down       | `j`, `<down>`             | Move cursor down                                             |
+| move_left       | `h`, `<left>`             | Move cursor left                                             |
+| move_right      | `l`, `<right>`            | Move cursor right                                            |
+| select_focus    | `<enter>`                 | Toggle select current item                                   |
+| select_parent   | `p`                       | Move cursor to the parent item                               |
+| select_first    | `g`                       | Move cursor to the top                                       |
+| select_last     | `G`                       | Move cursor to the bottom                                    |
+| close_parent    | `<backspace>`             | Move cursor to the parent and close                          |
 | change_root     | `r`                       | Change current item as root<br/>Use `reset` action to recover |
-| reset           | `<esc>`                   | Reset cursor and items                                        |
-| page_up         | `<page-up>`, `<ctrl-y>`   | Scroll up                                                     |
-| page_down       | `<page-down>`, `<ctrl-e>` | Scroll down                                                   |
-| change_layout   | `v`                       | Change current layout                                         |
-| tree_scale_up   | `[`                       | Scale up tree widget                                          |
-| tree_scale_down | `]`                       | Scale down tree widget                                        |
-| switch          | `<tab>`                   | Switch focus widget                                           |
-| quit            | `<ctrl-c>`, `q`           | Quit program                                                  |
+| reset           | `<esc>`                   | Reset cursor and items                                       |
+| page_up         | `<page-up>`, `<ctrl-y>`   | Scroll up                                                    |
+| page_down       | `<page-down>`, `<ctrl-e>` | Scroll down                                                  |
+| change_layout   | `v`                       | Change current layout                                        |
+| tree_scale_up   | `[`                       | Scale up tree widget                                         |
+| tree_scale_down | `]`                       | Scale down tree widget                                       |
+| switch          | `<tab>`                   | Switch focus widget                                          |
+| edit            | `e`                       | Open current item in editor<br />**Notice that edited changes won't be saved** |
+| quit            | `<ctrl-c>`, `q`           | Quit program                                                 |
 
 All available keys:
 

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -240,6 +240,9 @@ pub struct Keys {
     #[serde(default = "Keys::default_switch")]
     pub switch: Vec<String>,
 
+    #[serde(default = "Keys::default_edit")]
+    pub edit: Vec<String>,
+
     #[serde(default = "Keys::default_quit")]
     pub quit: Vec<String>,
 
@@ -265,6 +268,7 @@ generate_keys_default!(
     tree_scale_up => ["["],
     tree_scale_down => ["]"],
     switch => ["<tab>"],
+    edit => ["e"],
     quit => ["<ctrl-c>", "q"]
 );
 
@@ -286,6 +290,7 @@ generate_actions!(
     tree_scale_up => TreeScaleUp,
     tree_scale_down => TreeScaleDown,
     switch => Switch,
+    edit => Edit,
     quit => Quit
 );
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,9 @@ use self::types::Types;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
+    #[serde(default = "Editor::default")]
+    pub editor: Editor,
+
     #[serde(default = "Data::default")]
     pub data: Data,
 
@@ -35,6 +38,18 @@ pub struct Config {
 
     #[serde(default = "Keys::default")]
     pub keys: Keys,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Editor {
+    #[serde(default = "Editor::default_program")]
+    pub program: String,
+
+    #[serde(default = "Editor::default_args")]
+    pub args: Vec<String>,
+
+    #[serde(default = "Editor::default_dir")]
+    pub dir: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,6 +155,7 @@ impl Config {
 
     pub fn default() -> Self {
         Self {
+            editor: Editor::default(),
             data: Data::default(),
             layout: Layout::default(),
             header: Header::default(),
@@ -162,6 +178,31 @@ impl Config {
 
     fn empty_map() -> HashMap<String, String> {
         HashMap::new()
+    }
+}
+
+impl Editor {
+    fn default() -> Self {
+        Self {
+            program: Self::default_program(),
+            args: Self::default_args(),
+            dir: Self::default_dir(),
+        }
+    }
+
+    fn default_program() -> String {
+        if let Some(editor) = env::var_os("EDITOR") {
+            return editor.to_string_lossy().to_string();
+        }
+        String::from("vim")
+    }
+
+    fn default_args() -> Vec<String> {
+        vec![String::from("{file}")]
+    }
+
+    fn default_dir() -> String {
+        String::from("/tmp")
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,0 +1,105 @@
+use std::{
+    fs,
+    io::{self, Read, Write},
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use anyhow::{bail, Context, Result};
+
+use crate::config::Config;
+
+pub struct Edit {
+    path: String,
+    data: String,
+    cmd: Command,
+}
+
+impl Edit {
+    pub fn new(cfg: &Config, identify: String, data: String, extension: &'static str) -> Self {
+        let mut cmd = Command::new(&cfg.editor.program);
+        cmd.stdin(Stdio::inherit());
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+
+        let name = identify.replace('/', "_");
+        let path = PathBuf::from(&cfg.editor.dir).join(format!("otree_{name}.{extension}"));
+        let path = format!("{}", path.display());
+
+        for arg in cfg.editor.args.iter() {
+            if !arg.contains("{file}") {
+                cmd.arg(arg);
+                continue;
+            }
+
+            let arg = arg.replace("{file}", &path);
+            cmd.arg(arg);
+        }
+
+        Self { path, data, cmd }
+    }
+
+    pub fn run(mut self) {
+        if let Err(err) = self._run() {
+            eprintln!("Edit error: {err:#}");
+            eprintln!();
+            eprintln!("Press any key to continue...");
+            io::stdout().flush().unwrap();
+
+            // Wait for a single character input
+            let mut buffer = [0; 1];
+            io::stdin().read_exact(&mut buffer).unwrap();
+        }
+    }
+
+    fn _run(&mut self) -> Result<()> {
+        self.write_file().context("write edit file")?;
+
+        let result = self.edit_file().context("edit file");
+        if result.is_err() {
+            let _ = self.delete_file();
+            return result;
+        }
+
+        self.delete_file().context("delete edit file")?;
+        Ok(())
+    }
+
+    fn write_file(&self) -> Result<()> {
+        let path = PathBuf::from(&self.path);
+        if let Some(dir) = path.parent() {
+            match fs::metadata(dir) {
+                Ok(meta) => {
+                    if !meta.is_dir() {
+                        bail!("'{}' is not a directory", dir.display());
+                    }
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    fs::create_dir_all(dir)
+                        .with_context(|| format!("create directory '{}'", dir.display()))?;
+                }
+                Err(err) => {
+                    return Err(err)
+                        .with_context(|| format!("get metadata for '{}'", dir.display()))
+                }
+            }
+        }
+
+        fs::write(&path, &self.data)
+            .with_context(|| format!("write data to file '{}'", path.display()))?;
+
+        Ok(())
+    }
+
+    fn edit_file(&mut self) -> Result<()> {
+        let status = self.cmd.status().context("execute editor command")?;
+        if !status.success() {
+            bail!("editor command exited with bad code");
+        }
+        Ok(())
+    }
+
+    fn delete_file(&self) -> Result<()> {
+        fs::remove_file(&self.path).with_context(|| format!("delete file '{}'", self.path))
+    }
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,9 +1,7 @@
-use std::{
-    fs,
-    io::{self, Read, Write},
-    path::PathBuf,
-    process::{Command, Stdio},
-};
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 use anyhow::{bail, Context, Result};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cmd;
 mod config;
+mod edit;
 mod parse;
 mod tree;
 mod ui;
@@ -105,15 +106,7 @@ fn run() -> Result<()> {
         app.set_header(header_ctx);
     }
 
-    let mut terminal = ui::start().context("start tui")?;
-    let result = app.show(&mut terminal).context("show tui");
-
-    // Regardless of how the TUI app executes, we should always restore the terminal.
-    // Otherwise, if the app encounters an error (such as a draw error), the user's terminal
-    // will become a mess.
-    ui::restore(terminal).context("restore terminal")?;
-
-    result
+    ui::start(app)
 }
 
 fn main() {

--- a/src/parse/json.rs
+++ b/src/parse/json.rs
@@ -6,6 +6,10 @@ use super::{Parser, SyntaxToken};
 pub(super) struct JsonParser {}
 
 impl Parser for JsonParser {
+    fn extension(&self) -> &'static str {
+        "json"
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         serde_json::from_str(data).context("parse JSON")
     }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -17,6 +17,8 @@ pub enum ContentType {
 }
 
 pub trait Parser {
+    fn extension(&self) -> &'static str;
+
     fn parse(&self, data: &str) -> Result<Value>;
 
     fn to_string(&self, value: &Value) -> String;

--- a/src/parse/toml.rs
+++ b/src/parse/toml.rs
@@ -9,6 +9,10 @@ use super::{Parser, SyntaxToken};
 pub(super) struct TomlParser {}
 
 impl Parser for TomlParser {
+    fn extension(&self) -> &'static str {
+        "toml"
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         let toml_value: TomlValue = toml::from_str(data).context("parse TOML")?;
         Ok(toml_value_to_json(toml_value))

--- a/src/parse/yaml.rs
+++ b/src/parse/yaml.rs
@@ -8,6 +8,10 @@ use super::{Parser, SyntaxToken};
 pub(super) struct YamlParser {}
 
 impl Parser for YamlParser {
+    fn extension(&self) -> &'static str {
+        "yaml"
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         let mut values = Vec::with_capacity(1);
         for document in serde_yml::Deserializer::from_str(data) {

--- a/src/ui/tree_overview.rs
+++ b/src/ui/tree_overview.rs
@@ -9,6 +9,7 @@ use tui_tree_widget::TreeState;
 
 use crate::config::keys::Action;
 use crate::config::Config;
+use crate::parse::Parser;
 use crate::tree::{Tree, TreeItem};
 use crate::ui::app::ScrollDirection;
 
@@ -41,6 +42,10 @@ impl<'a> TreeOverview<'a> {
 
     pub(super) fn get_item(&self, id: &str) -> Option<Rc<TreeItem>> {
         self.tree().get_item(id)
+    }
+
+    pub(super) fn get_parser(&self) -> Rc<Box<dyn Parser>> {
+        self.tree().get_parser()
     }
 
     pub(super) fn on_key(&mut self, action: Action) -> bool {


### PR DESCRIPTION
The new `edit` action. Default key binding is `e`.

With this, otree can open current item in system editor to let user better view or copy contents.

All the edited changes won't be saved. This is **readonly** to the original data.