### PR TITLE
fix: allow reading from stdin on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "filedescriptor",
  "mio",
  "parking_lot",
  "rustix",
@@ -356,6 +357,17 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "A command line tool to view objects (json/yaml/toml) in TUI tree 
 [dependencies]
 anyhow = "1.0.87"
 clap = { version = "4.5.17", features = ["derive"] }
-crossterm = "0.28.1"
+crossterm = { version = "0.28.1", features = ["use-dev-tty"] }
 dirs = "5.0.1"
 humansize = "2.1.3"
 once_cell = "1.19.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,13 +78,6 @@ fn run() -> Result<()> {
             fs::read(path).context("read file")?
         }
         None => {
-            if cfg!(target_os = "macos") {
-                // Read from stdin is not supported on macOS.
-                // See: <https://github.com/crossterm-rs/crossterm/issues/500>
-                bail!(
-                    "reading data from stdin is not supported on macOS, please read it from file"
-                );
-            }
             let mut data = Vec::new();
             io::stdin().read_to_end(&mut data).context("read stdin")?;
             data


### PR DESCRIPTION
The issue with crossterm referenced [here](https://github.com/fioncat/otree/blob/5ebc059e2f79c2ebea8d84e3938172cbe856ef3e/src/main.rs#L83) has been fixed.

This PR merely allows macOS to read from stdin.