### PR TITLE
fix(expand_children): set state even in error case

### DIFF
--- a/src/ui/tree_overview.rs
+++ b/src/ui/tree_overview.rs
@@ -185,6 +185,7 @@ impl TreeOverview {
             }
         }
 
+        self.state = Some(state);
         false
     }
 


### PR DESCRIPTION
fixes #87. literally just the patch from https://github.com/fioncat/otree/issues/87 but as pr so i can point nix to a commit instead of having to make a patch file in my config tree