### PR TITLE
feat(parse): improve syntax highlighting for toml

### DIFF
--- a/src/parse/toml.rs
+++ b/src/parse/toml.rs
@@ -18,11 +18,23 @@ impl Parser for TomlParser {
         Ok(toml_value_to_json(toml_value))
     }
 
-    fn syntax_highlight(&self, _name: &str, value: &Value) -> Vec<SyntaxToken> {
-        if let Value::Array(_) = value {
-            return json_highlight(value, 0, false);
+    fn syntax_highlight(&self, name: &str, value: &Value) -> Vec<SyntaxToken> {
+        let mut section = None;
+        let mut arr_complex = false;
+        if let Value::Array(arr) = value {
+            section = Some(name);
+
+            for value in arr {
+                match value {
+                    Value::Object(_) | Value::Array(_) => {
+                        arr_complex = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
         }
-        let mut tokens = highlight(value, None, false, false);
+        let mut tokens = highlight(value, section, false, arr_complex);
         if !tokens.is_empty() {
             // Trim the first break line
             let first_token = tokens.remove(0);

--- a/src/parse/toml.rs
+++ b/src/parse/toml.rs
@@ -21,18 +21,24 @@ impl Parser for TomlParser {
     fn syntax_highlight(&self, name: &str, value: &Value) -> Vec<SyntaxToken> {
         let mut section = None;
         let mut arr_complex = false;
-        if let Value::Array(arr) = value {
-            section = Some(name);
+        match value {
+            Value::Array(arr) => {
+                section = Some(name);
 
-            for value in arr {
-                match value {
-                    Value::Object(_) | Value::Array(_) => {
-                        arr_complex = true;
-                        break;
+                for value in arr {
+                    match value {
+                        Value::Object(_) | Value::Array(_) => {
+                            arr_complex = true;
+                            break;
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
+            Value::Object(_) => {
+                section = Some(name);
+            }
+            _ => {}
         }
         let mut tokens = highlight(value, section, false, arr_complex);
         if !tokens.is_empty() {


### PR DESCRIPTION
Now objects and arrays in toml will show section name.