### PR TITLE
feat(cmd): support convert data to another schema

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -9,8 +9,7 @@ use crate::parse::ContentType;
 #[derive(Parser, Debug)]
 #[command(disable_version_flag = true)]
 pub struct CommandArgs {
-    /// The file to read data. On non-macOS systems, this can be omitted, and data
-    /// will be read from stdin.
+    /// The file to read data. If this is empty, read from stdin.
     pub path: Option<String>,
 
     /// The config file to use. Default will try to read `~/.config/otree.toml`.
@@ -19,10 +18,14 @@ pub struct CommandArgs {
 
     #[expect(clippy::doc_link_with_quotes)] // false positive, it's just a list
     /// The data content type. If the file extension is one of
-    /// ["json", "yaml", "yml", "xml", "toml", "jsonl"], this can be automatically inferred. In other
-    /// cases, this is required.
+    /// ["json", "yaml", "yml", "xml", "toml", "hcl", "jsonl"], this can be automatically
+    // inferred. In other cases, this is required.
     #[clap(short = 't', long)]
     pub content_type: Option<ContentType>,
+
+    /// Convert data to another content type and print to stdout
+    #[clap(short = 'o', long)]
+    pub to: Option<ContentType>,
 
     /// Don't show the header.
     #[clap(long)]

--- a/src/parse/hcl.rs
+++ b/src/parse/hcl.rs
@@ -12,6 +12,10 @@ impl Parser for HclParser {
         "hcl"
     }
 
+    fn allow_array_root(&self) -> bool {
+        false
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         hcl::from_str(data).context("parse HCL")
     }

--- a/src/parse/json.rs
+++ b/src/parse/json.rs
@@ -10,6 +10,10 @@ impl Parser for JsonParser {
         "json"
     }
 
+    fn allow_array_root(&self) -> bool {
+        true
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         serde_json::from_str(data).context("parse JSON")
     }

--- a/src/parse/jsonl.rs
+++ b/src/parse/jsonl.rs
@@ -11,6 +11,10 @@ impl Parser for JsonlParser {
         "json"
     }
 
+    fn allow_array_root(&self) -> bool {
+        true
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         // Each line of the JSONL file is a JSON object
         let lines: Vec<&str> = data.lines().collect();

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -8,7 +8,7 @@ mod yaml;
 
 pub use syntax::SyntaxToken;
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use clap::ValueEnum;
 use serde_json::Value;
 
@@ -31,9 +31,31 @@ pub enum ContentType {
 pub trait Parser {
     fn extension(&self) -> &'static str;
 
+    fn allow_array_root(&self) -> bool;
+
     fn parse(&self, data: &str) -> Result<Value>;
 
     fn syntax_highlight(&self, name: &str, value: &Value) -> Vec<SyntaxToken>;
+
+    fn parse_root(&self, validator: Option<&dyn Parser>, data: &[u8]) -> Result<Value> {
+        let data = String::from_utf8(data.to_vec()).context("parse content utf8")?;
+        let value = self.parse(&data)?;
+
+        match value {
+            Value::Object(_) => {}
+            Value::Array(_) => {
+                let allow =
+                    validator.map_or_else(|| self.allow_array_root(), Parser::allow_array_root);
+                if !allow {
+                    let schema = validator.map_or_else(|| self.extension(), Parser::extension);
+                    bail!("schema '{schema}' does not allow array as root");
+                }
+            }
+            _ => bail!("root value must be either object or array"),
+        }
+
+        Ok(value)
+    }
 }
 
 impl ContentType {

--- a/src/parse/toml.rs
+++ b/src/parse/toml.rs
@@ -13,6 +13,10 @@ impl Parser for TomlParser {
         "toml"
     }
 
+    fn allow_array_root(&self) -> bool {
+        false
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         let toml_value: TomlValue = toml::from_str(data).context("parse TOML")?;
         Ok(toml_value_to_json(toml_value))

--- a/src/parse/xml.rs
+++ b/src/parse/xml.rs
@@ -16,6 +16,10 @@ impl Parser for XmlParser {
         "xml"
     }
 
+    fn allow_array_root(&self) -> bool {
+        false
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         let mut reader = Reader::from_str(data);
 

--- a/src/parse/yaml.rs
+++ b/src/parse/yaml.rs
@@ -12,6 +12,10 @@ impl Parser for YamlParser {
         "yaml"
     }
 
+    fn allow_array_root(&self) -> bool {
+        true
+    }
+
     fn parse(&self, data: &str) -> Result<Value> {
         let mut values = Vec::with_capacity(1);
         for document in serde_yml::Deserializer::from_str(data) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -60,9 +60,9 @@ pub enum FieldType {
 }
 
 impl Tree {
-    pub fn parse(cfg: Rc<Config>, data: &str, content_type: ContentType) -> Result<Self> {
+    pub fn parse(cfg: Rc<Config>, data: &[u8], content_type: ContentType) -> Result<Self> {
         let parser = content_type.new_parser();
-        let value = parser.parse(data)?;
+        let value = parser.parse_root(None, data)?;
         Ok(Self::from_value(cfg, value, Rc::new(parser)))
     }
 


### PR DESCRIPTION
Add `--to` or `-o` command line option, to convert current data to another schema.

For example, from JSON to TOML:

  otree /path/to/file.json -o toml

This will print TOML content to stdout.