### PR TITLE
Add PageUp/PageDown support for Data Block view

### DIFF
--- a/src/ui/data_block.rs
+++ b/src/ui/data_block.rs
@@ -53,6 +53,8 @@ impl DataBlock {
             Action::MoveUp => self.scroll_up(1),
             Action::MoveRight => self.scroll_right(1),
             Action::MoveLeft => self.scroll_left(1),
+            Action::PageUp => self.scroll_up(5),
+            Action::PageDown => self.scroll_down(5),
             Action::SelectFirst => self.scroll_first(),
             Action::SelectLast => self.scroll_last(),
             _ => false,


### PR DESCRIPTION
Add support for scrolling using PageUp and PageDown keys in Data Block view.

Fixes #124 