### PR TITLE
feat(tree): add minijinja template for object node descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
+name = "minijinja"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+dependencies = [
+ "memo-map",
+ "serde",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +859,7 @@ dependencies = [
  "dirs",
  "hcl-rs",
  "humansize",
+ "minijinja",
  "notify",
  "paste",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crossterm = { version = "0.28", features = ["use-dev-tty"] }
 dirs = "^6"
 hcl-rs = "^0"
 humansize = "^2"
+minijinja = { version = "^2", default-features = false, features = ["builtins", "serde"] }
 notify = "^8"
 paste = "^1"
 quick-xml = { version = "^0", features = ["serialize"] }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -47,6 +47,11 @@ pub struct CommandArgs {
     #[clap(long)]
     pub tree_selected_symbol: Option<String>,
 
+    /// A minijinja template rendered against each object node and appended to its
+    /// description, docker `--format` style. E.g. `--tree-format '{{ id }}'`.
+    #[clap(long)]
+    pub tree_format: Option<String>,
+
     /// Ignore case when filtering.
     #[clap(long)]
     pub filter_ignore_case: bool,
@@ -172,6 +177,10 @@ impl CommandArgs {
 
         if let Some(ref symbol) = self.tree_selected_symbol {
             cfg.tree.selected_symbol.clone_from(symbol);
+        }
+
+        if let Some(ref format) = self.tree_format {
+            cfg.tree.format.clone_from(format);
         }
 
         if self.filter_ignore_case {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,11 @@ pub struct Tree {
 
     #[serde(default = "String::new")]
     pub selected_symbol: String,
+
+    /// A minijinja template rendered against each object node and appended to its
+    /// `{ N fields }` description, docker `--format` style. Empty disables it.
+    #[serde(default = "String::new")]
+    pub format: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,6 +160,7 @@ impl Config {
         self.validate_palette()?;
         self.colors.parse(&self.palette)?;
         self.keys.parse()?;
+        self.tree.parse()?;
         Ok(())
     }
 
@@ -229,11 +235,36 @@ impl Config {
 }
 
 impl Tree {
+    /// The template name registered in the minijinja environment.
+    pub const FORMAT_TEMPLATE: &'static str = "tree_format";
+
     fn default() -> Self {
         Self {
             disable_selected_highlight: Config::disable(),
             selected_symbol: String::new(),
+            format: String::new(),
         }
+    }
+
+    fn parse(&self) -> Result<()> {
+        // Validate the format template compiles up-front so a syntax error is a
+        // clear startup failure rather than surfacing while rendering the tree.
+        self.build_env()
+            .context("parse tree format template")
+            .map(|_| ())
+    }
+
+    /// Build a minijinja environment with the tree format template registered, or
+    /// `None` when no format is configured. Missing attributes render empty
+    /// (lenient) so an absent key just omits the suffix.
+    pub fn build_env(&self) -> Result<Option<minijinja::Environment<'static>>> {
+        if self.format.is_empty() {
+            return Ok(None);
+        }
+        let mut env = minijinja::Environment::new();
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Lenient);
+        env.add_template_owned(Self::FORMAT_TEMPLATE, self.format.clone())?;
+        Ok(Some(env))
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use anyhow::Result;
+use minijinja::Environment;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span, Text};
 use serde_json::Value;
@@ -18,6 +19,9 @@ pub struct Tree {
     pub values: HashMap<String, ItemValue>,
 
     pub identifies: Vec<String>,
+
+    /// Compiled `cfg.tree.format` template, `None` when no format is configured.
+    format_env: Option<Environment<'static>>,
 
     cfg: Rc<Config>,
 }
@@ -56,11 +60,15 @@ impl Tree {
     }
 
     pub fn from_value(cfg: Rc<Config>, value: Value, parser: Rc<Box<dyn Parser>>) -> Self {
+        // The format template is validated in `Config::parse`, so a compile error
+        // here would be a bug; degrade to no format rather than panic.
+        let format_env = cfg.tree.build_env().unwrap_or(None);
         let mut tree = Self {
             parser,
             items: vec![],
             values: HashMap::new(),
             identifies: vec![],
+            format_env,
             cfg,
         };
 
@@ -235,11 +243,15 @@ impl Tree {
                 )
             }
             Value::Object(obj) => {
-                let description = format!(
+                let mut description = format!(
                     "{{ {} {} }}",
                     obj.len(),
                     if obj.len() > 1 { "fields" } else { "field" }
                 );
+                if let Some(suffix) = self.render_format(&raw_value) {
+                    description.push(' ');
+                    description.push_str(&suffix);
+                }
                 let data_name = arr_name.unwrap_or(&name);
                 let tokens = self.parser.syntax_highlight(data_name, &raw_value);
                 let text = Self::build_item_text(
@@ -273,6 +285,23 @@ impl Tree {
 
         self.values.insert(path, value);
         item
+    }
+
+    /// Render the configured format template against an object node's value,
+    /// returning the trimmed output, or `None` when no format is configured or
+    /// the result is blank (e.g. every referenced attribute was absent).
+    fn render_format(&self, value: &Value) -> Option<String> {
+        let env = self.format_env.as_ref()?;
+        let tmpl = env
+            .get_template(crate::config::Tree::FORMAT_TEMPLATE)
+            .ok()?;
+        let rendered = tmpl.render(value).ok()?;
+        let trimmed = rendered.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
     }
 
     fn build_item_text(
@@ -407,5 +436,98 @@ impl ItemValue {
                 ignore_case,
             }),
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse::ContentType;
+
+    /// Build a tree from JSON `data` with the given `tree.format`, then return the
+    /// description of the node at `path`.
+    fn describe(format: &str, data: &str, path: &str) -> String {
+        let mut cfg = Config::default();
+        cfg.tree.format = format.to_string();
+        cfg.parse().expect("config should be valid");
+
+        let parser = ContentType::Json.new_parser();
+        let value = parser.parse_root(None, data.as_bytes()).unwrap();
+        let tree = Tree::from_value(Rc::new(cfg), value, Rc::new(parser));
+
+        tree.get_value(path)
+            .unwrap_or_else(|| panic!("no node at path {path:?}"))
+            .description
+            .to_string()
+    }
+
+    #[test]
+    fn no_format_keeps_default_description() {
+        let desc = describe("", r#"{"item": {"id": 42, "name": "x"}}"#, "item");
+        assert_eq!(desc, "{ 2 fields }");
+    }
+
+    #[test]
+    fn injects_scalar_attribute() {
+        let desc = describe("{{ id }}", r#"{"item": {"id": 42, "name": "x"}}"#, "item");
+        assert_eq!(desc, "{ 2 fields } 42");
+    }
+
+    #[test]
+    fn supports_literal_text_and_multiple_attributes() {
+        let desc = describe(
+            "id={{ id }} name={{ name }}",
+            r#"{"item": {"id": 42, "name": "x"}}"#,
+            "item",
+        );
+        assert_eq!(desc, "{ 2 fields } id=42 name=x");
+    }
+
+    #[test]
+    fn absent_attribute_renders_empty_and_skips_suffix() {
+        // `id` is missing; lenient undefined renders empty, so no suffix is added.
+        let desc = describe("{{ id }}", r#"{"item": {"name": "x"}}"#, "item");
+        assert_eq!(desc, "{ 1 field }");
+    }
+
+    #[test]
+    fn non_scalar_attribute_is_rendered_by_the_engine() {
+        // Referencing an object attribute yields the engine's map repr, not a scalar.
+        // Guarding against that is a template author concern; the default template
+        // (a single `{{ key }}`) is expected to point at scalar fields.
+        let desc = describe(
+            "{{ id | default('') }}",
+            r#"{"item": {"id": 7, "meta": {"a": 1}}}"#,
+            "item",
+        );
+        assert_eq!(desc, "{ 2 fields } 7");
+    }
+
+    #[test]
+    fn supports_filters_and_conditionals() {
+        let desc = describe(
+            "{% if active %}#{{ id }}{% endif %}",
+            r#"{"item": {"id": 3, "active": true}}"#,
+            "item",
+        );
+        assert_eq!(desc, "{ 2 fields } #3");
+    }
+
+    #[test]
+    fn format_only_applies_to_objects() {
+        // A string node keeps its own description, untouched by the format.
+        let desc = describe(
+            "{{ id }}",
+            r#"{"item": {"greeting": "hello"}}"#,
+            "item/greeting",
+        );
+        assert_eq!(desc, "= \"hello\"");
+    }
+
+    #[test]
+    fn invalid_template_is_rejected_at_config_parse() {
+        let mut cfg = Config::default();
+        cfg.tree.format = "{{ id ".to_string();
+        assert!(cfg.parse().is_err());
     }
 }


### PR DESCRIPTION
## Summary

Object nodes previously showed only a `{ N fields }` size summary in the tree — nothing about their contents. This adds an opt-in, docker `--format`-style templated description for object nodes, powered by [minijinja](https://crates.io/crates/minijinja) (Jinja2 syntax).

A template is rendered against each object node's value and its output appended to the node's description:

```
otree data.json --tree-format '{{ id }}'
# object node:  { 3 fields } 42

otree data.json --tree-format 'id={{ id }} {{ name | upper }}'
# object node:  { 3 fields } id=42 X
```

## Usage

Set the template either on the command line or in the config file:

- CLI: `--tree-format '{{ id }}'`
- Config: `[tree]` → `format = "{{ id }}"`

Because the node value is the render context, the full Jinja2 surface is available — literals, filters, conditionals, nested paths:

```jinja
{% if active %}#{{ id }}{% endif %}
{{ [meta.a, meta.b, meta.c] | select | join(' - ') }}
```

## Behavior

- **Objects only.** Scalars and arrays keep their existing descriptions untouched.
- **Lenient undefined.** A template referencing a key the node lacks renders empty, so the suffix is simply omitted (`{ 1 field }`, no error).
- **Validated once at startup.** A malformed template fails at config-parse time with a clear message and non-zero exit, rather than surfacing while rendering the tree.
- **Empty by default.** With no `tree.format` configured, behavior is unchanged.

## Why minijinja

- Ecosystem-standard minimal template engine (single required dep, `serde`, already present); pulled in with `default-features = false, features = ["builtins", "serde"]` to keep the footprint small.
- Each object node's `serde_json::Value` *is* the render context, so there is almost no glue code.
- The template is compiled once and only interpreted per node.

The existing header `{token}` formatting is left as-is — it uses `{ }` fixed-token replacement, distinct from minijinja's `{{ }}`, so there is no syntax collision.

## Changes

| File | Change |
| --- | --- |
| `Cargo.toml` | Add `minijinja` dependency |
| `src/config/mod.rs` | New `tree.format` config field; validate the template at startup; `build_env()` helper |
| `src/cmd.rs` | New `--tree-format` CLI arg + wiring |
| `src/tree.rs` | Compile the template once on `Tree`; render + append for object nodes; 8 unit tests |

## Testing

- `cargo test` — 17 pass (8 new, covering: default description unchanged, scalar injection, literals + multiple attributes, absent-key skipped, filters/conditionals, objects-only scope, invalid-template rejection).
- `cargo check`, `cargo fmt --check`, `typos`, `cargo clippy` — all clean.
